### PR TITLE
Connected disableDragonAreaSpawns config option to the relevant event

### DIFF
--- a/src/main/java/com/dragonfight/event/EventHandler.java
+++ b/src/main/java/com/dragonfight/event/EventHandler.java
@@ -50,7 +50,7 @@ public class EventHandler
          */
         if (event.getLevel() instanceof ServerLevel && ((ServerLevel) event.getLevel()).dimension() == Level.END && DragonFightManagerCustom.isFightRunning)
         {
-            if (BlockPos.ZERO.distToCenterSqr(event.getX(), 64.0d, event.getZ()) < 300 * 300)
+            if (BlockPos.ZERO.distToCenterSqr(event.getX(), 64.0d, event.getZ()) < 300 * 300 && DragonfightMod.config.getCommonConfig().disableDragonAreaSpawns)
             {
                 event.setSpawnCancelled(true);
             }


### PR DESCRIPTION
It seems like the connection between the disableDragonAreaSpawns config option and the spawn event cancellation code is missing, at least for NeoForge. This pr makes that connection.